### PR TITLE
Update new projects document

### DIFF
--- a/RelatedProjects.md
+++ b/RelatedProjects.md
@@ -1,0 +1,5 @@
+# Related projects
+
+Projects related to the Open Data Cube but which are not currently part of the project:
+
+* *Your project here!*

--- a/RelatedProjects.md
+++ b/RelatedProjects.md
@@ -1,5 +1,0 @@
-# Related projects
-
-Projects related to the Open Data Cube but which are not currently part of the project:
-
-* *Your project here!*

--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -89,8 +89,6 @@ The possible recommendations of the Steering Council will be:
   incubating under the [opendatacube-incubator](https://github.com/opendatacube-incubator) GitHub
   organization, its repository will be removed from that organization after a transition period.
 
-External projects may still be linked to in the [Related Projects](RelatedProjects.md) document.
-
 ### Incorporation
 
 When an existing external Subproject is incorporated as a new official Subproject, the following

--- a/newsubprojects.md
+++ b/newsubprojects.md
@@ -16,12 +16,11 @@ Open Data Cube organization. These apply to any Subproject, regardless of who is
 Subproject. Subprojects should:
 
 * Have an active developer community that offers a sustainable model for future development.
-* Have an active user community.
 * Use solid software engineering with documentation and tests hosted with appropriate
   technologies ([Read The Docs](https://readthedocs.org/) and [Travis](https://travis-ci.org/)
   are examples of technologies that can be used).
 * Demonstrate continued growth and development.
-* Integrate well with other official Subprojects.
+* Integrate well with other official Subprojects where appropriate.
 * Be developed according to the Open Data Cube [governance and contribution model](https://github.com/opendatacube/governance).
 * Have a well-defined scope.
 * Be packaged using appropriate technologies such as pip, conda, npm, bower, docker, etc.
@@ -90,6 +89,7 @@ The possible recommendations of the Steering Council will be:
   incubating under the [opendatacube-incubator](https://github.com/opendatacube-incubator) GitHub
   organization, its repository will be removed from that organization after a transition period.
 
+External projects may still be linked to in the [Related Projects](RelatedProjects.md) document.
 
 ### Incorporation
 


### PR DESCRIPTION
Some of the things originally in this document probably aren't as relevant to such a small project as the Open Data Cube, for example demonstration of an active user community - often projects in this organisation will only (initially) have users who are the developers of the project. Some of these changes are more suggestions and open to discussion.