### PR TITLE
Removing IDEAM as ODC Institutional Partner

### DIFF
--- a/people.md
+++ b/people.md
@@ -28,7 +28,6 @@ Institutional Council members are noted with each institution.
 - [CSIRO](https://www.csiro.au/)
 - [NASA](https://www.nasa.gov/)
 - [AMA](http://www.ama-inc.com/)
-- [IDEAM](http://www.ideam.gov.co/)
 - [USGS](https://www.usgs.gov/)
 
 ## New Steering Council Members


### PR DESCRIPTION
IDEAM no longer appear to fulfil the criteria for an ODC Institutional Partner per governance.