### PR TITLE
Make language more accessible

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -6,50 +6,44 @@ section below, is contained in The Project Governance Repository at:
 
 [https://github.com/opendatacube/governance](https://github.com/opendatacube/governance)
 
-## The Project
+## The Open Data Cube Project
 
-The **Open Data Cube** (The Project) is an open source software project. The goal of The Project is to develop open source software and deploy open and public websites and services that provide a new approach for organising and analysing the vast quantities of satellite imagery and other Earth observation data, making it quicker and easier to use in diverse fields ranging across environment, water quality, hazards and agriculture. The Software developed
-by The Project is released under the **Apache 2** (or similar) open source license,
-developed openly and hosted in public GitHub repositories under the
-[Open Data Cube GitHub organization](https://github.com/opendatacube). Examples of
-Project Software include the Data Cube Core, the CEOS UI, other algorithms, and user interfaces, etc.
-The Services run by the Project consist of public websites and web-services that are hosted
-under the opendatacube.org domain. An example of
-a Project Service includes the Open Data Cube website
-([http://opendatacube.org](http://opendatacube.org)).
+The **Open Data Cube** (ODC) is an open source software project. The aims of the ODC project are: to develop open source software; and to deploy open public websites and services. These open ODC products and services provide new approaches to analysing and organising vast quantities of satellite imagery and other Earth observation data. This makes Earth observation data quicker and easier to use in diverse fields ranging across environment, water quality, hazards and agriculture. Software released by the ODC project is licensed  under the [Apache 2](https://www.apache.org/licenses/LICENSE-2.0) open source license. ODC software is developed openly and hosted in public GitHub repositories under the
+[Open Data Cube GitHub organization](https://github.com/opendatacube). ODC project software includes the [Data Cube Core](https://github.com/opendatacube/datacube-core).
+The Services run by the Project consist of public websites and web-services that are hosted under the opendatacube.org domain. An example of a Project Service includes the Open Data Cube website ([http://opendatacube.org](http://opendatacube.org)).
 
-The Project is developed by a team of distributed developers, called
+The ODC project is developed by a team of distributed developers, called
 **Contributors**. Contributors are individuals who have contributed code,
-documentation, designs or other work to one or more Project repositories.
+documentation, designs or other work to one or more ODC repositories.
 Anyone can be a Contributor. Contributors can be affiliated with any legal
 entity or none. Contributors participate in the project by submitting,
 reviewing and discussing GitHub Pull Requests and Issues and participating in
-open and public Project discussions on GitHub, Slack, Google Groups, and mailing lists. The foundation of Project participation is openness and transparency.
+open and public Project discussions on GitHub, Slack, Google Groups, and mailing lists. The foundation of ODC participation is openness and transparency.
 
-There are also many other Contributors listed in the logs of other repositories of
+There are many other Contributors listed in the logs of other repositories of
 the Open Data Cube project.
 
-The **Project Community** consists of all Contributors and Users of the Project.
+The **ODC Community** consists of all Contributors and users of the ODC.
 Contributors work on behalf of and are responsible to the larger Project
-Community and we strive to keep the barrier between Contributors and Users as
+Community and we strive to keep the barrier between Contributors and users as
 low as possible.
 
 ## Governance
 
 This section describes the governance and leadership model of The Project.
 
-The foundations of Project governance are:
+The foundations of ODC project governance are:
 
 - Openness & Transparency
 - Active Contribution
 - Institutional Neutrality
 
-The Project leadership will consist a Steering Council, made up of a group of ongoing
+The ODC project leadership will consist a Steering Council, made up of a group of ongoing
 active contributors.
 
 ## Chair of Steering Council
 
-The Project will have a Chair of the Steering Council. The Chair has the authority to make all final decisions for The Project. In practice the Chair chooses to defer that authority to the consensus of the community discussion channels and the Steering Council (see below). It is expected that the Chair will only rarely assert his/her final authority. Because rarely used, we refer to the Chair’s final authority as a “special” or “overriding” vote. When it does occur, the Chair override typically happens in situations where there is a deadlock in the Steering Council or if the Steering Council asks the Chair to make a decision on a specific matter. To ensure the integrity of The Project, The Project encourages others to fork the project if they disagree with the overall direction the Steering Council. The Chair may delegate his/her authority on a particular decision or set of decisions to any other Council member at his/her discretion.
+The ODC project will have a Chair of the Steering Council. The Chair has the authority to make all final decisions for the ODC project. In practice the Chair chooses to defer that authority to the consensus of the community discussion channels and the Steering Council (see below). It is expected that the Chair will only rarely assert his/her final authority. Because rarely used, we refer to the Chair’s final authority as a “special” or “overriding” vote. When it does occur, the Chair override typically happens in situations where there is a deadlock in the Steering Council or if the Steering Council asks the Chair to make a decision on a specific matter. To ensure the integrity of the ODC project, we encourage others to fork the project if they disagree with the overall direction the Steering Council. The Chair may delegate his/her authority on a particular decision or set of decisions to any other Council member at his/her discretion.
 
 The Chair will be selected from amongst the Steering Council membership and reside in that role for a period of twelve months in duration, at which time the position will rotate to another member of the Steering Council (where possible from an alternative organisation affiliation).
 
@@ -57,7 +51,7 @@ Chairs are selected by self nomination, and if there is more than on nominee, th
 
 ## Steering Council
 
-The Project will have a **Steering Council** that consists of Project Contributors
+The ODC project will have a **Steering Council** that consists of ODC Contributors
 who have produced contributions that are substantial in quality and quantity,
 and sustained over at least one year. The overall role of the Council is to
 ensure the long-term well-being of the project, both technically and as a community.
@@ -66,8 +60,8 @@ During the everyday project activities, **Council Members** participate in all
 discussions, code review and other project activities as peers with all other
 Contributors and the Community. In these everyday activities, Council Members
 do not have any special power or privilege through their membership on the
-Council. However, it is expected that because of the quality and quantity of
-their contributions and their expert knowledge of the Project Software and
+Council. It is expected that because of the quality and quantity of
+their contributions and their knowledge of the ODC Software and
 Services that Council Members will provide useful guidance, both technical and
 in terms of project direction, to potentially less experienced contributors.
 
@@ -81,15 +75,15 @@ In particular, the Council may:
 - Make decisions about specific technical issues, features, bugs and pull
     requests. They are the primary mechanism of guiding the code review process
     and merging pull requests.
-- Make decisions about the Services that are run by The Project and manage
-    those Services for the benefit of the Project and Community.
+- Make decisions about the Services that are run by the ODC project and manage
+    those Services for the benefit of the ODC Community.
 - Make decisions when regular community discussion doesn’t produce consensus
     on an issue in a reasonable time frame.
 
 ### Council membership
 
-To become eligible for being a Steering Council Member an individual must be a
-Project Contributor who has produced contributions that are substantial in
+To become eligible for being a Steering Council Member an individual must be an
+ODC Contributor who has produced contributions that are substantial in
 quality and quantity, and sustained over at least one year. Potential Council
 Members are nominated by existing Council members and voted upon by the
 existing Council after asking if the potential Member is interested and willing
@@ -116,7 +110,7 @@ vote. If they plan on returning to active participation soon, they will be
 given a grace period of one year. If they don’t return to active participation
 within that time period they will be removed by vote of the Council without
 further grace period. All former Council members can be considered for
-membership again at any time in the future, like any other Project Contributor.
+membership again at any time in the future, like any other ODC Contributor.
  Retired Council members will be listed on the project website, acknowledging
 the period during which they were active in the Council.
 
@@ -132,9 +126,9 @@ it is possible that Members will have conflict of interests. Such conflict of
 interests include, but are not limited to:
 
 - Financial interests, such as investments, employment or contracting work,
-    outside of The Project that may influence their work on The Project.
+    outside of the ODC that may influence their work on the ODC project.
 - Access to proprietary information of their employer that could potentially
-    leak into their work with The Project.
+    leak into their work within the ODC project.
 
 All members of the Council, Chair included, shall disclose to the rest of the
 Council any conflict of interest they may have. Members with a conflict of
@@ -144,7 +138,7 @@ issue, but must recuse themselves from voting on the issue. If the Chair has rec
 ### Private communications of the Council
 
 Unless specifically required, all Council discussions and activities will be
-public and done in collaboration and discussion with the Project Contributors
+public and done in collaboration and discussion with Contributors
 and Community. The Council will have a private mailing list that will be used
 sparingly and only when a specific matter requires privacy. When private
 communications and decisions are needed, the Council will do its best to
@@ -182,7 +176,7 @@ Licenses for commercial data will be vary.
 ## Changing the Governance Documents
 
 Changes to the governance documents are submitted via a GitHub pull
-request to The Project's governance documents GitHub repository at
+request to the ODC project governance documents GitHub repository at
 [https://github.com/opendatacube/governance](https://github.com/opendatacube/governance).
 The pull request is then refined in response to public comment and
 review, with the goal being consensus in the community.  After this


### PR DESCRIPTION
update "The Project" to "the ODC" , "the ODC project" or ODC, to reflect common usage in the ODC community and make docs more accessible. Added some links to mentioned repos, and generally began making language more accessible and inclusive to encourage membership interest from outside current members. Increase readability and reduce tautologies.