### PR TITLE
Update council members

### DIFF
--- a/people.md
+++ b/people.md
@@ -8,14 +8,14 @@ Names are followed by GitHub usernames.
 - Paul Haesler, @SpacemanPaul ([Geoscience Australia](http://www.ga.gov.au/))
 - Kirill Kouzoubov, @Kirill888 (independent)
 - Alex Leith, @alexgleith ([Geoscience Australia](http://www.ga.gov.au/))
+- Edward Boamah, @nanaboamah89 ([Digital Earth Africa](https://www.digitalearthafrica.org/))
 - Damien Ayers, @omad ([Geoscience Australia](http://www.ga.gov.au/))
 - Robbi Bishop-Taylor, @robbibt ([Geoscience Australia](http://www.ga.gov.au/))
 - Randall Sunne ([USGS](https://www.usgs.gov/))
 - Tony Butzer, @tonybutzer ([USGS](https://www.usgs.gov/))
-- Syed Rizvi, @srrizvi (Chair from June 2020 - June 2021) ([AMA](http://www.ama-inc.com/))
+- Syed Rizvi, @srrizvi ([AMA](http://www.ama-inc.com/))
 - Andrew Cherry, @AMA-AC ([AMA](http://www.ama-inc.com/))
-- Chris Morgan, @chriscmorgan (FrontierSI)
-- Caitlin Adams, @caitlinadams (FrontierSI)
+- Caitlin Adams, @caitlinadams (Chair from July 2022 - June 2023) ([FrontierSI](https://frontiersi.com.au/))
 - George Dyke, @gamedaygeorge ([Symbios](http://symbios.space))
 - Stephan Meißl ([EOX](https://eox.at/))
 - Fabian Schindler, @constantinius ([EOX]())
@@ -29,3 +29,8 @@ The following tasks need to be completed when a new member joins the steering co
 - Announce the new member on the Open Data Cube mailing list
 - Make the new member an org owner and Open Data Cube Github organizations
 - Add the new member to the list in the governance repo, and if appropriate, add their affiliation to the [institutional partner list](people.md)
+
+## Previous Chairs
+- Syed Rizvi, @srrizvi (July 2021 - June 2022)
+- Alex Leith, @alexgleith (July 2020 - June 2021)
+- Rob Woodcock, @woodcockr (July 2019 - June 2020)


### PR DESCRIPTION
An update to council members, including addition of Edward Boamah and removal of Chris Morgan. 

Added a new section to list previous steering council chairs and their tenure.