### PR TITLE
Update people.md

### DIFF
--- a/people.md
+++ b/people.md
@@ -4,7 +4,7 @@ Names are followed by GitHub usernames.
 
 ## Current Steering Council Members
 
-- Damien Ayers, @omad (Chair from July 2025 - June 2026) ([CSIRO](https://www.csiro.au/))
+- Damien Ayers, @omad ([CSIRO](https://www.csiro.au/))
 - Paul Haesler, @SpacemanPaul ([Geoscience Australia](http://www.ga.gov.au/))
 - Rob Woodcock, @woodcockr ([CSIRO](https://www.csiro.au/))
 - Kirill Kouzoubov, @Kirill888 (independent)
@@ -17,7 +17,7 @@ Names are followed by GitHub usernames.
 - George Dyke, @gamedaygeorge ([Symbios](http://symbios.space))
 - Ariana Barzinpour, @Ariana-B ([Geoscience Australia](http://www.ga.gov.au/))
 - Alex Leith, @alexgleith ([Auspatious](https://auspatious.com/))
-- Peter A. Jonsson, @pjonsson ([RISE](https://ri.se/en))
+- Peter A. Jonsson, @pjonsson (Chair from July 2026 - June 2027) ([RISE](https://ri.se/en))
 
 ## New Steering Council Members
 
@@ -36,6 +36,7 @@ All steering council members become administrators of the GitHub Organisation on
 The various levels of repository access will be refined and realigned to fit with Github based [administration process](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization) by the steering council as time progresses.
 
 ## Previous Chairs
+- Damien Ayers, @omad (July 2025 - June 2026)
 - Paul Haesler, @SpacemanPaul (July 2024 - June 2025)
 - Rob Woodcock, @woodcockr (July 2023 - June 2024)
 - Caitlin Adams, @caitlinadams (July 2022 - June 2023)


### PR DESCRIPTION
Mark Peter J as current chair, and add Damien's last term to historic chair list.